### PR TITLE
Calling the overlay bar configuration block if set

### DIFF
--- a/Blobfish/Classes/Blobfish.swift
+++ b/Blobfish/Classes/Blobfish.swift
@@ -135,6 +135,8 @@ public class Blobfish {
     //MARK: - Overlay -
     
     private func showOverlayBar() {
+        overlayBarConfiguration?(Blobfish.sharedInstance.overlayBar)    
+        
         if (self.overlayBar.isHidden) { // Not already shown
             // Do not re-animate
             self.overlayBar.frame.origin.y = -overlayBar.frame.height


### PR DESCRIPTION
Right now it is not possible to use the configuration block of the the overlay styled blob. This is fixed by running the block in the showOverlayBar method. However im not sure this is the right place. 