### PR TITLE
Hotfix/ iPhone x alert message bar height

### DIFF
--- a/Blobfish.xcodeproj/project.pbxproj
+++ b/Blobfish.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		01BBF0121DE23979003AC718 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01BBF0081DE23966003AC718 /* Alamofire.framework */; };
+		2341B7262029CC9C00BECE13 /* LayoutUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2341B7252029CC9C00BECE13 /* LayoutUtils.swift */; };
 		296995931E39469D005B0B6C /* BlobfishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BA21231C957E3100DC883C /* BlobfishTests.swift */; };
 		307ED5341C98AEE7002B7B74 /* Blobfish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BA212F1C957F1500DC883C /* Blobfish.swift */; };
 		30925AF81C95892E00895BE6 /* Blobable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BA21301C957F1500DC883C /* Blobable.swift */; };
@@ -33,6 +34,7 @@
 		01BBF0081DE23966003AC718 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		01BBF00C1DE23966003AC718 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		01BBF00F1DE23966003AC718 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
+		2341B7252029CC9C00BECE13 /* LayoutUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutUtils.swift; sourceTree = "<group>"; };
 		30925AFA1C9589B800895BE6 /* Blob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blob.swift; sourceTree = "<group>"; };
 		30BA21141C957E3100DC883C /* Blobfish.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Blobfish.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		30BA21171C957E3100DC883C /* Blobfish.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Blobfish.h; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				30925AFA1C9589B800895BE6 /* Blob.swift */,
 				30BA21301C957F1500DC883C /* Blobable.swift */,
 				30BA21331C957F1500DC883C /* AlamofireBlobfishExtension.swift */,
+				2341B7252029CC9C00BECE13 /* LayoutUtils.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				30BA21391C957F7E00DC883C /* MessageBar.swift in Sources */,
+				2341B7262029CC9C00BECE13 /* LayoutUtils.swift in Sources */,
 				30925AF81C95892E00895BE6 /* Blobable.swift in Sources */,
 				307ED5341C98AEE7002B7B74 /* Blobfish.swift in Sources */,
 				30925AFB1C9589B800895BE6 /* Blob.swift in Sources */,

--- a/Blobfish.xcodeproj/project.pbxproj
+++ b/Blobfish.xcodeproj/project.pbxproj
@@ -418,7 +418,7 @@
 				);
 				INFOPLIST_FILE = Blobfish/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nodes.Blobfish;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -441,7 +441,7 @@
 				);
 				INFOPLIST_FILE = Blobfish/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/Carthage/Build/iOS";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nodes.Blobfish;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Blobfish.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Blobfish.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Blobfish/Classes/Blobfish.swift
+++ b/Blobfish/Classes/Blobfish.swift
@@ -23,7 +23,7 @@ public class Blobfish {
     var reachabilityManager: NetworkReachabilityManager?
 
     //safe area top added for iphone x so message bar isnt displayed under the notch
-    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop()))
+    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.extraLabelHeightForMessageBar()))
     
     var alertWindow = UIWindow(frame: UIScreen.main.bounds) {
         didSet {
@@ -184,7 +184,7 @@ public class Blobfish {
         self.overlayBar.transform = transformForOrientation(orientation)
         
         //status bar frame with safe area layout
-        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop())
+        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.extraLabelHeightForMessageBar())
         
         if UIInterfaceOrientationIsLandscape(orientation) {
             frame = frame.rectByReversingSize()

--- a/Blobfish/Classes/Blobfish.swift
+++ b/Blobfish/Classes/Blobfish.swift
@@ -23,7 +23,7 @@ public class Blobfish {
     var reachabilityManager: NetworkReachabilityManager?
 
     //safe area top added for iphone x so message bar isnt displayed under the notch
-    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height /*+ LayoutUtils.safeAreaTop()*/))
+    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.extraLabelHeightForMessageBar()))
     
     var alertWindow = UIWindow(frame: UIScreen.main.bounds) {
         didSet {
@@ -184,7 +184,7 @@ public class Blobfish {
         self.overlayBar.transform = transformForOrientation(orientation)
         
         //status bar frame with safe area layout
-        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height /*+ LayoutUtils.safeAreaTop()*/)
+        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.extraLabelHeightForMessageBar())
         
         if UIInterfaceOrientationIsLandscape(orientation) {
             frame = frame.rectByReversingSize()

--- a/Blobfish/Classes/Blobfish.swift
+++ b/Blobfish/Classes/Blobfish.swift
@@ -183,7 +183,8 @@ public class Blobfish {
         
         self.overlayBar.transform = transformForOrientation(orientation)
         
-        var frame = UIApplication.shared.statusBarFrame
+        //status bar frame with safe area layout
+        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop())
         
         if UIInterfaceOrientationIsLandscape(orientation) {
             frame = frame.rectByReversingSize()

--- a/Blobfish/Classes/Blobfish.swift
+++ b/Blobfish/Classes/Blobfish.swift
@@ -22,7 +22,8 @@ public class Blobfish {
 
     var reachabilityManager: NetworkReachabilityManager?
 
-    lazy var overlayBar = MessageBar(frame: UIApplication.shared.statusBarFrame)
+    //safe area top added for iphone x so message bar isnt displayed under the notch
+    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop()))
     
     var alertWindow = UIWindow(frame: UIScreen.main.bounds) {
         didSet {

--- a/Blobfish/Classes/Blobfish.swift
+++ b/Blobfish/Classes/Blobfish.swift
@@ -23,7 +23,7 @@ public class Blobfish {
     var reachabilityManager: NetworkReachabilityManager?
 
     //safe area top added for iphone x so message bar isnt displayed under the notch
-    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.extraLabelHeightForMessageBar()))
+    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop()))
     
     var alertWindow = UIWindow(frame: UIScreen.main.bounds) {
         didSet {
@@ -184,7 +184,7 @@ public class Blobfish {
         self.overlayBar.transform = transformForOrientation(orientation)
         
         //status bar frame with safe area layout
-        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.extraLabelHeightForMessageBar())
+        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop())
         
         if UIInterfaceOrientationIsLandscape(orientation) {
             frame = frame.rectByReversingSize()

--- a/Blobfish/Classes/Blobfish.swift
+++ b/Blobfish/Classes/Blobfish.swift
@@ -23,7 +23,7 @@ public class Blobfish {
     var reachabilityManager: NetworkReachabilityManager?
 
     //safe area top added for iphone x so message bar isnt displayed under the notch
-    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop()))
+    lazy var overlayBar = MessageBar(frame: CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height /*+ LayoutUtils.safeAreaTop()*/))
     
     var alertWindow = UIWindow(frame: UIScreen.main.bounds) {
         didSet {
@@ -184,7 +184,7 @@ public class Blobfish {
         self.overlayBar.transform = transformForOrientation(orientation)
         
         //status bar frame with safe area layout
-        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height + LayoutUtils.safeAreaTop())
+        var frame = CGRect.init(x: UIApplication.shared.statusBarFrame.origin.x, y: UIApplication.shared.statusBarFrame.origin.y, width: UIApplication.shared.statusBarFrame.size.width, height: UIApplication.shared.statusBarFrame.size.height /*+ LayoutUtils.safeAreaTop()*/)
         
         if UIInterfaceOrientationIsLandscape(orientation) {
             frame = frame.rectByReversingSize()

--- a/Blobfish/Classes/LayoutUtils.swift
+++ b/Blobfish/Classes/LayoutUtils.swift
@@ -24,4 +24,13 @@ public struct LayoutUtils {
         
         return 0.0
     }
+    
+    public static func hasTopNotch() -> Bool {
+        if #available(iOS 11.0, tvOS 11.0, *) {
+            // with notch: 44.0 on iPhone X, XS, XS Max, XR.
+            // without notch: 24.0 on iPad Pro 12.9" 3rd generation, 20.0 on iPhone 8 on iOS 12+.
+            return UIApplication.shared.delegate?.window??.safeAreaInsets.top ?? 0 > 24
+        }
+        return false
+    }
 }

--- a/Blobfish/Classes/LayoutUtils.swift
+++ b/Blobfish/Classes/LayoutUtils.swift
@@ -11,8 +11,8 @@ import Foundation
 public struct LayoutUtils {
     
     public static func extraLabelHeightForMessageBar() -> CGFloat {
-        //15.0 is the height of the label in the message bar
-        return safeAreaTop() > 0.0 ? 15.0 : 0.0
+        //16.0 is the height of the label in the message bar
+        return safeAreaTop() > 0.0 ? 16.0 : 0.0
     }
     
     public static func safeAreaTop() -> CGFloat {

--- a/Blobfish/Classes/LayoutUtils.swift
+++ b/Blobfish/Classes/LayoutUtils.swift
@@ -9,6 +9,11 @@
 import Foundation
 
 public struct LayoutUtils {
+    
+    public static func extraLabelHeightForMessageBar() -> CGFloat {
+        return safeAreaTop() > 0.0 ? 15.0 : 0.0
+    }
+    
     public static func safeAreaTop() -> CGFloat {
         if #available(iOS 11.0, *) {
             if let window = UIApplication.shared.keyWindow {

--- a/Blobfish/Classes/LayoutUtils.swift
+++ b/Blobfish/Classes/LayoutUtils.swift
@@ -1,0 +1,21 @@
+//
+//  LayoutUtils.swift
+//  Blobfish
+//
+//  Created by Andrew Lloyd - Nodes on 06/02/2018.
+//  Copyright © 2018 Nodes. All rights reserved.
+//
+
+import Foundation
+
+public struct LayoutUtils {
+    public static func safeAreaTop() -> CGFloat {
+        if #available(iOS 11.0, *) {
+            if let window = UIApplication.shared.keyWindow {
+                return window.safeAreaInsets.top
+            }
+        }
+        
+        return 0.0
+    }
+}

--- a/Blobfish/Classes/LayoutUtils.swift
+++ b/Blobfish/Classes/LayoutUtils.swift
@@ -11,6 +11,7 @@ import Foundation
 public struct LayoutUtils {
     
     public static func extraLabelHeightForMessageBar() -> CGFloat {
+        //15.0 is the height of the label in the message bar
         return safeAreaTop() > 0.0 ? 15.0 : 0.0
     }
     

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -17,6 +17,7 @@ public class MessageBar: UIWindow {
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
         label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.safeAreaTop()
+        label.bounds.size.height = 15.0
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -16,8 +16,8 @@ public class MessageBar: UIWindow {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.safeAreaTop()
-        label.bounds.size.height = label.bounds.size.height - LayoutUtils.safeAreaTop()
+        label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.extraLabelHeightForMessageBar()
+        label.bounds.size.height = label.bounds.size.height - LayoutUtils.extraLabelHeightForMessageBar()
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -17,7 +17,7 @@ public class MessageBar: UIWindow {
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-//        label.frame.size.height = 16.0
+        label.frame.size.height = 16.0
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear
@@ -28,9 +28,9 @@ public class MessageBar: UIWindow {
         }
         self.label.lineBreakMode = NSLineBreakMode.byTruncatingTail
         self.label.numberOfLines = 1
-//        self.label.minimumScaleFactor = 0.5
+        self.label.minimumScaleFactor = 0.5
         self.label.textColor = UIColor.white
-        self.label.font = UIFont.preferredFont(forTextStyle: .callout)
+        self.label.font = UIFont.boldSystemFont(ofSize: 14)
         self.backgroundColor = UIColor.red
         self.isHidden = true
         self.windowLevel = UIWindowLevelStatusBar+1;
@@ -39,8 +39,8 @@ public class MessageBar: UIWindow {
     public override func layoutSubviews() {
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
         label.frame.origin.y = LayoutUtils.safeAreaTop()
+        label.frame.size.height = 16.0
         label.center = self.center
-//        label.frame.size.height = 16.0
         label.sizeToFit()
     }
     

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -16,8 +16,8 @@ public class MessageBar: UIWindow {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.frame.origin.y = label.frame.origin.y - LayoutUtils.safeAreaTop()
-        //label.frame.size.height = label.frame.size.height - LayoutUtils.extraLabelHeightForMessageBar()
+        label.frame.origin.y = LayoutUtils.safeAreaTop()
+        label.frame.size.height = 15.0
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear
@@ -38,8 +38,8 @@ public class MessageBar: UIWindow {
     
     public override func layoutSubviews() {
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
-        label.frame.origin.y = label.frame.origin.y - LayoutUtils.safeAreaTop()
-        //label.frame.size.height = label.frame.size.height - LayoutUtils.extraLabelHeightForMessageBar()
+        label.frame.origin.y = LayoutUtils.safeAreaTop()
+        label.frame.size.height = 15.0
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -17,7 +17,6 @@ public class MessageBar: UIWindow {
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
         label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.safeAreaTop()
-        label.bounds.size.height = label.bounds.size.height - LayoutUtils.safeAreaTop()
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -28,9 +28,9 @@ public class MessageBar: UIWindow {
         }
         self.label.lineBreakMode = NSLineBreakMode.byTruncatingTail
         self.label.numberOfLines = 1
-//        self.label.minimumScaleFactor = 0.2
+        self.label.minimumScaleFactor = 0.5
         self.label.textColor = UIColor.white
-        self.label.font = UIFont.preferredFont(forTextStyle: .headline)
+        self.label.font = UIFont.systemFont(ofSize: 13)
         label.sizeToFit()
         self.backgroundColor = UIColor.red
         self.isHidden = true

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -16,6 +16,8 @@ public class MessageBar: UIWindow {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.safeAreaTop()
+        label.bounds.size.height = label.bounds.size.height - LayoutUtils.safeAreaTop()
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -30,7 +30,7 @@ public class MessageBar: UIWindow {
         self.label.numberOfLines = 1
         self.label.minimumScaleFactor = 0.2
         self.label.textColor = UIColor.white
-        self.label.font = UIFont.systemFont(ofSize: 8)
+        self.label.font = UIFont.preferredFont(forTextStyle: .subheadline)
         self.backgroundColor = UIColor.red
         self.isHidden = true
         self.windowLevel = UIWindowLevelStatusBar+1;

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -16,7 +16,7 @@ public class MessageBar: UIWindow {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.frame.origin.y = label.frame.origin.y + LayoutUtils.safeAreaTop()
+        label.frame.origin.y = label.frame.origin.y - LayoutUtils.safeAreaTop()
         //label.frame.size.height = label.frame.size.height - LayoutUtils.extraLabelHeightForMessageBar()
         self.addSubview(label)
         
@@ -38,7 +38,7 @@ public class MessageBar: UIWindow {
     
     public override func layoutSubviews() {
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
-        label.frame.origin.y = label.frame.origin.y + LayoutUtils.safeAreaTop()
+        label.frame.origin.y = label.frame.origin.y - LayoutUtils.safeAreaTop()
         //label.frame.size.height = label.frame.size.height - LayoutUtils.extraLabelHeightForMessageBar()
     }
     

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -13,40 +13,45 @@ public class MessageBar: UIWindow {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-
+        
         self.translatesAutoresizingMaskIntoConstraints = false
+        
         label.translatesAutoresizingMaskIntoConstraints = false
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-        label.frame.size.height = 16.0
+        label.frame.size.height = 18.0
         self.addSubview(label)
         
-        self.label.backgroundColor = UIColor.clear
-        self.label.textAlignment = NSTextAlignment.center
-        self.label.adjustsFontSizeToFitWidth = true
+        label.textAlignment = NSTextAlignment.center
+        label.backgroundColor = UIColor.clear
+        label.adjustsFontSizeToFitWidth = true
         if #available(iOS 9, *) {
             self.label.allowsDefaultTighteningForTruncation = true
         }
-        self.label.lineBreakMode = NSLineBreakMode.byTruncatingTail
-        self.label.numberOfLines = 1
-        self.label.minimumScaleFactor = 0.5
-        self.label.textColor = UIColor.white
-        self.label.font = UIFont.boldSystemFont(ofSize: 14)
-        self.backgroundColor = UIColor.red
-        self.isHidden = true
-        self.windowLevel = UIWindowLevelStatusBar+1;
+        label.lineBreakMode = NSLineBreakMode.byTruncatingTail
+        label.numberOfLines = 1
+        label.textColor = UIColor.white
+        label.font = UIFont.preferredFont(forTextStyle: .callout)
+        
+        backgroundColor = UIColor.red
+        isHidden = true
+        windowLevel = UIWindowLevelStatusBar+1;
     }
     
     public override func layoutSubviews() {
+        
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-        label.frame.size.height = 16.0
-        label.center = self.center
-        label.sizeToFit()
+        label.frame.size.height = 18.0
+        
+        if LayoutUtils.hasTopNotch() {
+            label.center = CGPoint(x: center.x, y: center.y + 14)
+        } else {
+            label.center = self.center
+        }
+        
     }
     
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
-
-

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -16,8 +16,8 @@ public class MessageBar: UIWindow {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.bounds.origin.y = self.bounds.size.height - 15.0
-        label.bounds.size.height = 15.0
+        label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.safeAreaTop()
+        label.bounds.size.height = label.bounds.size.height - LayoutUtils.safeAreaTop()
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -16,8 +16,8 @@ public class MessageBar: UIWindow {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.extraLabelHeightForMessageBar()
-        label.bounds.size.height = label.bounds.size.height - LayoutUtils.extraLabelHeightForMessageBar()
+        label.frame.origin.y = label.frame.origin.y + LayoutUtils.safeAreaTop()
+        //label.frame.size.height = label.frame.size.height - LayoutUtils.extraLabelHeightForMessageBar()
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear
@@ -38,6 +38,8 @@ public class MessageBar: UIWindow {
     
     public override func layoutSubviews() {
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
+        label.frame.origin.y = label.frame.origin.y + LayoutUtils.safeAreaTop()
+        //label.frame.size.height = label.frame.size.height - LayoutUtils.extraLabelHeightForMessageBar()
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -17,7 +17,7 @@ public class MessageBar: UIWindow {
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-        label.frame.size.height = 15.0
+        label.frame.size.height = 16.0
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear
@@ -28,9 +28,10 @@ public class MessageBar: UIWindow {
         }
         self.label.lineBreakMode = NSLineBreakMode.byTruncatingTail
         self.label.numberOfLines = 1
-        self.label.minimumScaleFactor = 0.2
+//        self.label.minimumScaleFactor = 0.2
         self.label.textColor = UIColor.white
-        self.label.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        self.label.font = UIFont.preferredFont(forTextStyle: .headline)
+        label.sizeToFit()
         self.backgroundColor = UIColor.red
         self.isHidden = true
         self.windowLevel = UIWindowLevelStatusBar+1;
@@ -39,7 +40,7 @@ public class MessageBar: UIWindow {
     public override func layoutSubviews() {
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-        label.frame.size.height = 15.0
+        label.frame.size.height = 16.0
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -39,9 +39,7 @@ public class MessageBar: UIWindow {
     public override func layoutSubviews() {
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-        if !LayoutUtils.hasTopNotch() {
-            label.center = self.center
-        }
+        label.center = self.center
 //        label.frame.size.height = 16.0
         label.sizeToFit()
     }

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -30,7 +30,7 @@ public class MessageBar: UIWindow {
         self.label.numberOfLines = 1
         self.label.minimumScaleFactor = 0.5
         self.label.textColor = UIColor.white
-        self.label.font = UIFont.systemFont(ofSize: 13)
+        self.label.font = UIFont.boldSystemFont(ofSize: 13)
         label.sizeToFit()
         self.backgroundColor = UIColor.red
         self.isHidden = true

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -16,7 +16,7 @@ public class MessageBar: UIWindow {
 
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.bounds.origin.y = label.bounds.origin.y + LayoutUtils.safeAreaTop()
+        label.bounds.origin.y = self.bounds.size.height - 15.0
         label.bounds.size.height = 15.0
         self.addSubview(label)
         

--- a/Blobfish/Classes/MessageBar.swift
+++ b/Blobfish/Classes/MessageBar.swift
@@ -17,7 +17,7 @@ public class MessageBar: UIWindow {
         self.translatesAutoresizingMaskIntoConstraints = false
         label.translatesAutoresizingMaskIntoConstraints = false
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-        label.frame.size.height = 16.0
+//        label.frame.size.height = 16.0
         self.addSubview(label)
         
         self.label.backgroundColor = UIColor.clear
@@ -28,10 +28,9 @@ public class MessageBar: UIWindow {
         }
         self.label.lineBreakMode = NSLineBreakMode.byTruncatingTail
         self.label.numberOfLines = 1
-        self.label.minimumScaleFactor = 0.5
+//        self.label.minimumScaleFactor = 0.5
         self.label.textColor = UIColor.white
-        self.label.font = UIFont.boldSystemFont(ofSize: 13)
-        label.sizeToFit()
+        self.label.font = UIFont.preferredFont(forTextStyle: .callout)
         self.backgroundColor = UIColor.red
         self.isHidden = true
         self.windowLevel = UIWindowLevelStatusBar+1;
@@ -40,10 +39,16 @@ public class MessageBar: UIWindow {
     public override func layoutSubviews() {
         label.frame = self.bounds.insetBy(dx: 8, dy: 0)
         label.frame.origin.y = LayoutUtils.safeAreaTop()
-        label.frame.size.height = 16.0
+        if !LayoutUtils.hasTopNotch() {
+            label.center = self.center
+        }
+//        label.frame.size.height = 16.0
+        label.sizeToFit()
     }
     
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+

--- a/BlobfishTests/BlobfishTests.swift
+++ b/BlobfishTests/BlobfishTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Blobfish
+//@testable import Blobfish
 
 class BlobfishTests: XCTestCase {
     

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4.1.0"
+github "Alamofire/Alamofire" "4.6.0"


### PR DESCRIPTION
I have updated the Message Bar to only show the text in the safe area (if supported). If we have a safe area, I add the height of the label (15) to the height of the bar and move the frame of the label down to show in the safe area.

I originally just added the whole space of the bar to make sure it was displayed in the safe area but this was covering up the whole navigation bar in apps and was using more space than necessary. This is why I only add the height of the label. The label is set to one line with the same font so it shouldn't change anyway.